### PR TITLE
Features and fixes from cburch824/KaosesTweaks

### DIFF
--- a/KaosesTweaks/Patches/CompanionSpawnPatch.cs
+++ b/KaosesTweaks/Patches/CompanionSpawnPatch.cs
@@ -12,9 +12,9 @@ namespace KaosesTweaks.Patches
   [HarmonyPatch(typeof(UrbanCharactersCampaignBehavior), "WeeklyTick")]
   class CompanionSpawnPatch
   {
-    private static bool Prefix(ref int ___randomCompanionSpawnFrequencyInWeeks)
+    private static bool Prefix(ref int ____randomCompanionSpawnFrequencyInWeeks)
     {
-      ___randomCompanionSpawnFrequencyInWeeks = MCMSettings.Instance.CompanionSpawnInterval;
+      ____randomCompanionSpawnFrequencyInWeeks = MCMSettings.Instance.CompanionSpawnInterval;
       return true;
     }
     static bool Prepare() => MCMSettings.Instance is { } settings && settings.CompanionSpawnInterval != 6;

--- a/KaosesTweaks/Patches/CompanionSpawnPatch.cs
+++ b/KaosesTweaks/Patches/CompanionSpawnPatch.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using KaosesTweaks.Settings;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+
+namespace KaosesTweaks.Patches
+{
+  [HarmonyPatch(typeof(UrbanCharactersCampaignBehavior), "WeeklyTick")]
+  class CompanionSpawnPatch
+  {
+    private static bool Prefix(ref int ___randomCompanionSpawnFrequencyInWeeks)
+    {
+      ___randomCompanionSpawnFrequencyInWeeks = MCMSettings.Instance.CompanionSpawnInterval;
+      return true;
+    }
+    static bool Prepare() => MCMSettings.Instance is { } settings && settings.CompanionSpawnInterval != 6;
+  }
+}

--- a/KaosesTweaks/Patches/KaosesSmithingPatches.cs
+++ b/KaosesTweaks/Patches/KaosesSmithingPatches.cs
@@ -98,10 +98,9 @@ namespace KaosesTweaks.Patches
     [HarmonyPatch(typeof(CraftingCampaignBehavior), "GetMaxHeroCraftingStamina")]
     public class GetMaxHeroCraftingStaminaPatch
     {
-        static bool Prefix(CraftingCampaignBehavior __instance, ref int __result)
+        static void Postfix(CraftingCampaignBehavior __instance, ref int __result)
         {
-            __result = MCMSettings.Instance is { } settings ? settings.MaxCraftingStamina : 100;
-            return false;
+            __result = MCMSettings.Instance is { } settings ? MathF.Round(settings.MaxCraftingStaminaMultiplier * __result)  : __result;
         }
 
         static bool Prepare() => MCMSettings.Instance is { } settings && settings.CraftingStaminaTweakEnabled;
@@ -125,18 +124,18 @@ namespace KaosesTweaks.Patches
             {
                 int curCraftingStamina = __instance.GetHeroCraftingStamina(hero);
 
-                if (!(MCMSettings.Instance is null) && curCraftingStamina < MCMSettings.Instance.MaxCraftingStamina)
+                if (!(MCMSettings.Instance is null) && curCraftingStamina < __instance.GetMaxHeroCraftingStamina(hero))
                 {
                     int staminaGainAmount = MCMSettings.Instance.CraftingStaminaGainAmount;
 
                     if (MCMSettings.Instance.CraftingStaminaGainOutsideSettlementMultiplier < 1 && hero.PartyBelongedTo?.CurrentSettlement == null)
                         staminaGainAmount = (int)Math.Ceiling(staminaGainAmount * MCMSettings.Instance.CraftingStaminaGainOutsideSettlementMultiplier);
 
-                    int diff = MCMSettings.Instance.MaxCraftingStamina - curCraftingStamina;
+                    int diff = __instance.GetMaxHeroCraftingStamina(hero) - curCraftingStamina;
                     if (diff < staminaGainAmount)
                         staminaGainAmount = diff;
 
-                    __instance.SetHeroCraftingStamina(hero, Math.Min(MCMSettings.Instance.MaxCraftingStamina, curCraftingStamina + staminaGainAmount));
+                    __instance.SetHeroCraftingStamina(hero, Math.Min(__instance.GetMaxHeroCraftingStamina(hero), curCraftingStamina + staminaGainAmount));
                 }
             }
             return false;

--- a/KaosesTweaks/Patches/KaosesSmithingPatches.cs
+++ b/KaosesTweaks/Patches/KaosesSmithingPatches.cs
@@ -178,7 +178,7 @@ namespace KaosesTweaks.Patches
 
             if (MCMSettings.Instance is { } settings && settings.PreventSmeltingLockedItems)
             {
-                List<string> locked_items = Campaign.Current.GetCampaignBehavior<ViewDataTracker>().InventoryGetLocks().ToList<string>();
+                List<string> locked_items = Campaign.Current.GetCampaignBehavior<ViewDataTrackerCampaignBehavior>().GetInventoryLocks().ToList<string>();
 
                 bool isLocked(ItemRosterElement item)
                 {

--- a/KaosesTweaks/Patches/LearningRatePatches.cs
+++ b/KaosesTweaks/Patches/LearningRatePatches.cs
@@ -1,11 +1,13 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using KaosesTweaks.Settings;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.SandBox.GameComponents;
+using TaleWorlds.Localization;
 
 namespace KaosesTweaks.Patches
 {
-  [HarmonyPatch(typeof(DefaultCharacterDevelopmentModel), "CalculateLearningLimit")]
+  [HarmonyPatch(typeof(DefaultCharacterDevelopmentModel), "CalculateLearningRate", new Type[]{typeof(int), typeof(int), typeof(int), typeof(int), typeof(TextObject), typeof(bool)})]
   public class LearningRatePatches
   {
     static void Postfix(ref ExplainedNumber __result)

--- a/KaosesTweaks/Patches/LearningRatePatches.cs
+++ b/KaosesTweaks/Patches/LearningRatePatches.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+using KaosesTweaks.Settings;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents;
+
+namespace KaosesTweaks.Patches
+{
+  [HarmonyPatch(typeof(DefaultCharacterDevelopmentModel), "CalculateLearningLimit")]
+  public class LearningRatePatches
+  {
+    static void Postfix(ref ExplainedNumber __result)
+    {
+      __result.LimitMin(MCMSettings.Instance.MinimumLearningRate);
+    }
+
+    static bool Prepare() => MCMSettings.Instance is { } settings && settings.MinimumLearningRate != 0.0f;
+  }
+}

--- a/KaosesTweaks/Patches/WorkshopsCampaignBehavior.cs
+++ b/KaosesTweaks/Patches/WorkshopsCampaignBehavior.cs
@@ -3,8 +3,10 @@ using KaosesTweaks.Settings;
 using KaosesTweaks.Utils;
 using System;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
 using TaleWorlds.Core;
+using TaleWorlds.Localization;
 
 
 namespace KaosesTweaks.Patches
@@ -84,6 +86,31 @@ namespace KaosesTweaks.Patches
         static bool Prepare() => MCMSettings.Instance is { } settings && settings.EnableWorkshopBuyTweak;
     }
 
+    [HarmonyPatch(typeof(ChangeOwnerOfWorkshopAction), "ApplyByWarDeclaration")]
+    class KeepWorkshopsOnWarDeclarationPatch
+    {
+      private static bool Prefix(Workshop workshop, Hero newOwner, WorkshopType workshopType, int capital, bool upgradable, TextObject customName = null)
+      {
+        if(MCMSettings.Instance is { } settings && settings.KeepWorkshopsOnWarDeclaration)
+          return false;
+
+        return true;
+      }
+      static bool Prepare() => MCMSettings.Instance is { } settings && settings.KeepWorkshopsOnWarDeclaration;
+    }
+
+    [HarmonyPatch(typeof(ChangeOwnerOfWorkshopAction), "ApplyByBankruptcy")]
+    class KeepWorkshopsOnBankruptcyPatch
+    {
+      private static bool Prefix(Workshop workshop, Hero newOwner, WorkshopType workshopType, int capital, bool upgradable, TextObject customName = null)
+      {
+        if (MCMSettings.Instance is { } settings && settings.KeepWorkshopsOnBankruptcy)
+          return false;
+
+        return true;
+      }
+      static bool Prepare() => MCMSettings.Instance is { } settings && settings.KeepWorkshopsOnBankruptcy;
+    }
 
     /*
         [HarmonyPatch(typeof(DefaultWorkshopModel), "DaysForPlayerSaveWorkshopFromBankruptcy")]

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -2609,12 +2609,12 @@ namespace KaosesTweaks.Settings
             SettingPropertyGroup("{=BT_Settings_008900}Workshops" + "/" + "{=BT_Settings_008901}Workshop Count Limit")]
         public bool MaxWorkshopCountTweakEnabled { get; set; } = false;
 
-        [SettingPropertyInteger("{=BT_Settings_008902}Base Workshop Count Limit", 0, 20, "0 Workshops", RequireRestart = false, Order = 2,
+        [SettingPropertyInteger("{=BT_Settings_008902}Base Workshop Count Limit", 0, 159, "0 Workshops", RequireRestart = false, Order = 2,
             HintText = "{=BT_Settings_008902_Desc}Native value is 1. Sets the base maximum number of workshops you can have."),
             SettingPropertyGroup("{=BT_Settings_008900}Workshops" + "/" + "{=BT_Settings_008901}Workshop Count Limit")]
         public int BaseWorkshopCount { get; set; } = 1;
 
-        [SettingPropertyInteger("{=BT_Settings_008903}Bonus Workshops Per Clan Tier", 0, 5, "0 Shops/Tier", RequireRestart = false, Order = 3,
+        [SettingPropertyInteger("{=BT_Settings_008903}Bonus Workshops Per Clan Tier", 0, 50, "0 Shops/Tier", RequireRestart = false, Order = 3,
             HintText = "{=BT_Settings_008903_Desc}Native value is 1. Sets the base maximum number of workshops you can have and the limit increase gained per clan tier."),
             SettingPropertyGroup("{=BT_Settings_008900}Workshops" + "/" + "{=BT_Settings_008901}Workshop Count Limit")]
         public int BonusWorkshopsPerClanTier { get; set; } = 1;

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -656,6 +656,11 @@ namespace KaosesTweaks.Settings
             HintText = "{=BT_Settings_003101_Desc}Sets the base companion limit. [Native: 3].")]
         [SettingPropertyGroup("{=BT_Settings_003000}Clan Tweaks" + "/" + "{=KTMCM_CCompanionLimit}Companion Limit")]
         public int ClanCompanionBaseLimit { get; set; } = 3;
+
+        [SettingPropertyInteger("{=BT_Settings_00310}Companion Spawn Interval", 0, 20, "0 Weeks", Order = 0, RequireRestart = false,
+          HintText = "{=BT_Settings_003104_Desc}Number of weeks between a new companion being added to the world. Set to 0 for a new companion to be added to the taverns every week. [Native: 6]")]
+        [SettingPropertyGroup("{=BT_Settings_003000}Clan Tweaks" + "/" + "{=KTMCM_CCompanionLimit}Companion Limit")]
+        public int CompanionSpawnInterval { get; set; } = 6;
         #endregion //~ Companion Limit
         #endregion //~ Clan
 

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -1660,15 +1660,23 @@ namespace KaosesTweaks.Settings
         [SettingPropertyGroup("{=BT_Settings_009000}Misc")]
         public bool UnlimitedWanderersPatch { get; set; } = false;
 
-        /* Disable in 1.5.7.2 until we understand changes to the main quest.
-        [SettingPropertyBool("Enable Auto-Extension of the 'Stop the Conspiracy' Quest", RequireRestart = false, HintText = "Automatically extends the timer of the 'Stop the Conspiracy' quest as TW hasn't finished it yet.")]
-        public bool TweakedConspiracyQuestTimerEnabled { get; set; } = true;
-        */
-        #endregion
+        //~ MinimumLearningRate
+        #region MinimumLearningRate
+        [SettingPropertyFloatingInteger("{=KTMCM_XPMMLR}Minimum Learning Rate", 0.0f, 16.0f, "#0.00", RequireRestart = true,
+          HintText = "{=KTMCM_XPMMLRH}Sets the minimum learning rate [Native : 0.0].")]
+        [SettingPropertyGroup("{=BT_Settings_009000}Misc")]
+        public float MinimumLearningRate { get; set; } = 0.0f;
+        #endregion //~ LearningLimitMultipliers
 
-        //~ Party Speeds
-        #region Kaoses Party Speeds
-        [SettingPropertyFloatingInteger("{=KPS_MSL}Minimum Speed limit", 0.1f, 3.5f, Order = 2, RequireRestart = false,
+    /* Disable in 1.5.7.2 until we understand changes to the main quest.
+    [SettingPropertyBool("Enable Auto-Extension of the 'Stop the Conspiracy' Quest", RequireRestart = false, HintText = "Automatically extends the timer of the 'Stop the Conspiracy' quest as TW hasn't finished it yet.")]
+    public bool TweakedConspiracyQuestTimerEnabled { get; set; } = true;
+    */
+    #endregion
+
+    //~ Party Speeds
+    #region Kaoses Party Speeds
+    [SettingPropertyFloatingInteger("{=KPS_MSL}Minimum Speed limit", 0.1f, 3.5f, Order = 2, RequireRestart = false,
             HintText = "{=KPS_MSLH}Set the lowest speed allowed for any party, if a parties speed would fall below this it will changed to the limit. [Native: 1.0f]")] //, "#0%"
         [SettingPropertyGroup("{=KPS_PartySpeeds}Party Speeds" + "/" + "{=KPS_Gloabal}Global", GroupOrder = 3)]
         public float KaosesmininumSpeedAmount { get; set; } = 1.0f;
@@ -2710,14 +2718,6 @@ namespace KaosesTweaks.Settings
             HintText = "{=KTMCM_XPMH}Enable modifying XP tweak variables.")]
         [SettingPropertyGroup("{=KTMCM_CXPTweaks}XP Tweaks")]
         public bool MCMSkillsXp { get; set; } = false;
-
-        //~ MinimumLearningRate
-        #region MinimumLearningRate
-        [SettingPropertyFloatingInteger("{=KTMCM_XPMMLR}Minimum Learning Rate", 0.0f, 16.0f, "#0%", RequireRestart = false,
-            HintText = "{=KTMCM_XPMMLRH}Sets the minimum learning rate [Native : 0.0].")]
-        [SettingPropertyGroup("{=KTMCM_CXPTweaks}XP Tweaks")]
-        public float MinimumLearningRate { get; set; } = 0.0f;
-        #endregion //~ LearningLimitMultipliers
 
         //~ Skills
         #region Skills

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -2684,6 +2684,19 @@ namespace KaosesTweaks.Settings
         [SettingPropertyGroup("{=BT_Settings_008900}Workshops" + "/" + "{=KTMCM_CBankruptcy}Bankruptcy")]
         public int WorkShopBankruptcyValue { get; set; } = 3;
         #endregion //~ Bankruptcy
+        
+        //~ Workshop Ownership Changes
+        #region Workshop Ownership Changes
+        [SettingPropertyBool("{=BT_Settings_008921}Workshops Kept on War Declarations", Order = 0, RequireRestart = true,
+            HintText = "{=BT_Settings_008922}Allows Player to Keep Their Workshops When a Kingdom Declares War [Native : false].")]
+        [SettingPropertyGroup("{=BT_Settings_008900}Workshops" + "/" + "{=BT_Settings_008920}Workshop Ownership Changes")]
+        public bool KeepWorkshopsOnWarDeclaration { get; set; } = false;
+
+        [SettingPropertyBool("{=BT_Settings_008923}Workshops Kept on Bankruptcy", Order = 0, RequireRestart = true,
+            HintText = "{=BT_Settings_008924}Allows Player to Keep Their Workshops on Bankruptcy [Native : false].")]
+        [SettingPropertyGroup("{=BT_Settings_008900}Workshops" + "/" + "{=BT_Settings_008920}Workshop Ownership Changes")]
+        public bool KeepWorkshopsOnBankruptcy { get; set; } = false;
+        #endregion //~ Workshop Ownership Changes
         #endregion //~ Workshops
 
         //~ XP Tweaks

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -2711,6 +2711,14 @@ namespace KaosesTweaks.Settings
         [SettingPropertyGroup("{=KTMCM_CXPTweaks}XP Tweaks")]
         public bool MCMSkillsXp { get; set; } = false;
 
+        //~ MinimumLearningRate
+        #region MinimumLearningRate
+        [SettingPropertyFloatingInteger("{=KTMCM_XPMMLR}Minimum Learning Rate", 0.0f, 16.0f, "#0%", RequireRestart = false,
+            HintText = "{=KTMCM_XPMMLRH}Sets the minimum learning rate [Native : 0.0].")]
+        [SettingPropertyGroup("{=KTMCM_CXPTweaks}XP Tweaks")]
+        public float MinimumLearningRate { get; set; } = 0.0f;
+        #endregion //~ LearningLimitMultipliers
+
         //~ Skills
         #region Skills
         [SettingPropertyBool("{=KTMCM_XPMSM}Skill XP Modifiers " + "*", IsToggle = true, Order = 0, RequireRestart = true,

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -697,10 +697,10 @@ namespace KaosesTweaks.Settings
             SettingPropertyGroup("{=BT_Settings_004000}Crafting Tweaks" + "/" + "{=BT_Settings_004100}Crafting Stamina")]
         public bool CraftingStaminaTweakEnabled { get; set; } = false;
 
-        [SettingPropertyInteger("{=BT_Settings_004101}Max Crafting Stamina", 100, 1000, "0 Stamina", Order = 2, RequireRestart = false,
-            HintText = "{=BT_Settings_004101_Desc}Native value is 400. Sets the maximum crafting stamina value."),
+        [SettingPropertyFloatingInteger("{=BT_Settings_004101}Max Crafting Stamina Multiplier", 0.0f, 10.0f, "0.00", Order = 2, RequireRestart = false,
+            HintText = "{=BT_Settings_004101_Desc}Multiply max crafting stamina by the multiplier [Native: 1.0]"),
             SettingPropertyGroup("{=BT_Settings_004000}Crafting Tweaks" + "/" + "{=BT_Settings_004100}Crafting Stamina")]
-        public int MaxCraftingStamina { get; set; } = 400;
+        public float MaxCraftingStaminaMultiplier { get; set; } = 1.0f;
 
         //~ Stamina Gains
         #region StaminGain
@@ -3061,7 +3061,7 @@ namespace KaosesTweaks.Settings
 
                 //~ Stamina Tweaks
                 CraftingStaminaTweakEnabled = false,
-                MaxCraftingStamina = 400,
+                MaxCraftingStaminaMultiplier = 1.0f,
 
                 //~ Stamina Gains
                 CraftingStaminaGainAmount = 5,
@@ -3727,7 +3727,7 @@ namespace KaosesTweaks.Settings
 
                 //~ Stamina Tweaks
                 CraftingStaminaTweakEnabled = true,
-                MaxCraftingStamina = 400,
+                MaxCraftingStaminaMultiplier = 1.0f,
 
                 //~ Stamina Gains
                 CraftingStaminaGainAmount = 5,
@@ -4382,7 +4382,7 @@ namespace KaosesTweaks.Settings
                 PreventSmeltingLockedItems = false,
                 CraftingStaminaGainAmount = 10,
                 CraftingStaminaGainOutsideSettlementMultiplier = 1.0f,
-                MaxCraftingStamina = 400,
+                MaxCraftingStaminaMultiplier = 1.0f,
                 CraftingStaminaTweakEnabled = true,
                 //IgnoreCraftingStamina = false,
 

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -1660,22 +1660,14 @@ namespace KaosesTweaks.Settings
         [SettingPropertyGroup("{=BT_Settings_009000}Misc")]
         public bool UnlimitedWanderersPatch { get; set; } = false;
 
-        //~ MinimumLearningRate
-        #region MinimumLearningRate
-        [SettingPropertyFloatingInteger("{=KTMCM_XPMMLR}Minimum Learning Rate", 0.0f, 16.0f, "#0.00", RequireRestart = true,
-          HintText = "{=KTMCM_XPMMLRH}Sets the minimum learning rate [Native : 0.0].")]
-        [SettingPropertyGroup("{=BT_Settings_009000}Misc")]
-        public float MinimumLearningRate { get; set; } = 0.0f;
-        #endregion //~ LearningLimitMultipliers
+        /* Disable in 1.5.7.2 until we understand changes to the main quest.
+        [SettingPropertyBool("Enable Auto-Extension of the 'Stop the Conspiracy' Quest", RequireRestart = false, HintText = "Automatically extends the timer of the 'Stop the Conspiracy' quest as TW hasn't finished it yet.")]
+        public bool TweakedConspiracyQuestTimerEnabled { get; set; } = true;
+        */
+        #endregion
 
-    /* Disable in 1.5.7.2 until we understand changes to the main quest.
-    [SettingPropertyBool("Enable Auto-Extension of the 'Stop the Conspiracy' Quest", RequireRestart = false, HintText = "Automatically extends the timer of the 'Stop the Conspiracy' quest as TW hasn't finished it yet.")]
-    public bool TweakedConspiracyQuestTimerEnabled { get; set; } = true;
-    */
-    #endregion
-
-    //~ Party Speeds
-    #region Kaoses Party Speeds
+        //~ Party Speeds
+        #region Kaoses Party Speeds
     [SettingPropertyFloatingInteger("{=KPS_MSL}Minimum Speed limit", 0.1f, 3.5f, Order = 2, RequireRestart = false,
             HintText = "{=KPS_MSLH}Set the lowest speed allowed for any party, if a parties speed would fall below this it will changed to the limit. [Native: 1.0f]")] //, "#0%"
         [SettingPropertyGroup("{=KPS_PartySpeeds}Party Speeds" + "/" + "{=KPS_Gloabal}Global", GroupOrder = 3)]
@@ -2864,6 +2856,14 @@ namespace KaosesTweaks.Settings
             HintText = "{=KTMCM_XPMLRMH}Multiply Learning Rate by the multiplier [Native : 1.0[100%]].")]
         [SettingPropertyGroup("{=KTMCM_CXPTweaks}XP Tweaks" + "/" + "{=KTMCM_CLearning}Learning Rate")]
         public float LearningRateMultiplier { get; set; } = 1.0f;
+
+        //~ MinimumLearningRate
+        #region MinimumLearningRate
+        [SettingPropertyFloatingInteger("{=KTMCM_XPMMLR}Minimum Learning Rate", 0.0f, 16.0f, "#0.00", RequireRestart = true,
+          HintText = "{=KTMCM_XPMMLRH}Sets the minimum learning rate [Native : 0.0].")]
+        [SettingPropertyGroup("{=KTMCM_CXPTweaks}XP Tweaks" + "/" + "{=KTMCM_CLearning}Learning Rate")]
+        public float MinimumLearningRate { get; set; } = 0.0f;
+        #endregion //~ LearningLimitMultipliers
         #endregion //~ LearningRateMultipliers
 
         //~ LearningLimitMultipliers

--- a/KaosesTweaks/Settings/MCMSettings.cs
+++ b/KaosesTweaks/Settings/MCMSettings.cs
@@ -647,12 +647,12 @@ namespace KaosesTweaks.Settings
         [SettingPropertyGroup("{=BT_Settings_003000}Clan Tweaks" + "/" + "{=KTMCM_CCompanionLimit}Companion Limit")]
         public bool ClanCompanionLimitEnabled { get; set; } = false;
 
-        [SettingPropertyInteger("{=KTMCM_CLMCLBC}Bonus Companions", 0, 10, "0 Companions", Order = 0, RequireRestart = false,
+        [SettingPropertyInteger("{=KTMCM_CLMCLBC}Bonus Companions", 0, 50, "0 Companions", Order = 0, RequireRestart = false,
             HintText = "{=KTMCM_CLMCLBCH}Additional Companion limit per clan tier [Native: 0].")]
         [SettingPropertyGroup("{=BT_Settings_003000}Clan Tweaks" + "/" + "{=KTMCM_CCompanionLimit}Companion Limit")]
         public int ClanAdditionalCompanionLimit { get; set; } = 0;
 
-        [SettingPropertyInteger("{=BT_Settings_003101}Base Companion Limit", 1, 20, "0 Companions", Order = 0, RequireRestart = false,
+        [SettingPropertyInteger("{=BT_Settings_003101}Base Companion Limit", 1, 50, "0 Companions", Order = 0, RequireRestart = false,
             HintText = "{=BT_Settings_003101_Desc}Sets the base companion limit. [Native: 3].")]
         [SettingPropertyGroup("{=BT_Settings_003000}Clan Tweaks" + "/" + "{=KTMCM_CCompanionLimit}Companion Limit")]
         public int ClanCompanionBaseLimit { get; set; } = 3;

--- a/KaosesTweaks/SubModule.cs
+++ b/KaosesTweaks/SubModule.cs
@@ -348,7 +348,7 @@ namespace KaosesTweaks
                     }
                     campaignGameStarter.AddModel(new KaosesBattleRewardModel());
                 }
-                if (settings.MCMCharacterDevlopmentModifiers || Statics._settings.LearningRateEnabled || Statics._settings.LearningLimitEnabled)
+                if (settings.MCMCharacterDevlopmentModifiers || Statics._settings.LearningRateMultiplier != 1.0  || Statics._settings.LearningLimitEnabled)
                 {
                     if (settings.Debug)
                     {

--- a/KaosesTweaks/_Module/ModuleData/std_kaosestweaks_strings.xml
+++ b/KaosesTweaks/_Module/ModuleData/std_kaosestweaks_strings.xml
@@ -883,6 +883,11 @@
     <string id="BT_Settings_008910_Desc" text="Alters the buying prices for input items of workshops."/>
     <string id="BT_Settings_008911" text="Workshop Products Buy Prices"/>
     <string id="BT_Settings_008911_Desc" text="Native value is 100%. Alters the buying prices for input items of workshops. Decrease for better profits." />
+    <string id="BT_Settings_008920" text="Workshop Ownership Changes"/>
+    <string id="BT_Settings_008921" text="Workshops Kept on War Declarations"/>
+    <string id="BT_Settings_008922" text="Allows Player to Keep Their Workshops When a Kingdom Declares War [Native : false]."/>
+    <string id="BT_Settings_008923" text="Workshops Kept on Bankruptcy"/>
+    <string id="BT_Settings_008924" text="Allows Player to Keep Their Workshops on Bankruptcy [Native : false]."/>
     <string id="BT_Settings_009000" text="Misc" />
     <string id="BT_Settings_009001" text="Disable Quest Troops Affecting Morale" />
     <string id="BT_Settings_009001_Desc" text="When enabled, quest troops such as Borrowed Troop in your party are ignored when party morale is calculated." />

--- a/KaosesTweaks/_Module/ModuleData/std_kaosestweaks_strings.xml
+++ b/KaosesTweaks/_Module/ModuleData/std_kaosestweaks_strings.xml
@@ -545,6 +545,8 @@
     <string id="BT_Settings_003102_Desc" text="Native value is 1. Sets the bonus to companion limit per clan tier. This value is multiplied by your clan tier. Note that Leadership 'We Pledge Our Swords' perk will also increse this number by 1." />
     <string id="BT_Settings_003103" text="Enable Unlimited Wanderers Patch"/>
     <string id="BT_Settings_003103_Desc" text="Removes the soft cap on the maximum number of potential companions who can spawn. Native limits the # of wanderers to ~25. This will remove that limit. Note: Requires a new campaign to take effect, as the cap is set when a new game is generated. Credit to Bleinz for his UnlimitedWanderers mod." />
+    <string id="BT_Settings_003104" text="Companion Spawn Interval" />
+    <string id="BT_Settings_003104_Desc" text="Number of weeks between a new companion being added to the world. Set to 0 for a new companion to be added to the taverns every week. [Native: 6]" />
     <string id="BT_Settings_003200" text="Party Limits" />
     <string id="BT_Settings_003200_Desc" text="Changes the number of parties you and ai lords can field and the bonus gained per clan tier." />
     <string id="BT_Settings_003201" text="Player Parties Limit"/>

--- a/KaosesTweaks/_Module/ModuleData/std_kaosestweaks_strings.xml
+++ b/KaosesTweaks/_Module/ModuleData/std_kaosestweaks_strings.xml
@@ -566,8 +566,8 @@
     <string id="BT_Settings_004000" text="Crafting Tweaks" />
     <string id="BT_Settings_004100" text="Crafting Stamina" />
     <string id="BT_Settings_004100_Desc" text="Enables tweaks which affect crafting stamina." />
-    <string id="BT_Settings_004101" text="Max Crafting Stamina"/>
-    <string id="BT_Settings_004101_Desc" text="Native value is 400. Sets the maximum crafting stamina value." />
+    <string id="BT_Settings_004101" text="Max Crafting Stamina Multiplier"/>
+    <string id="BT_Settings_004101_Desc" text="Multiply max crafting stamina by the multiplier [Native: 1.0]" />
     <string id="BT_Settings_004102" text="Crafting Stamina Gain"/>
     <string id="BT_Settings_004102_Desc" text="Native value is 5. You gain this amount of crafting stamina per hour." />
     <string id="BT_Settings_004103" text="Crafting Stamina Gain Outside Settlement"/>


### PR DESCRIPTION
New Features:
- Toggle to prevent workshop ownership changes on certain events (war, bankruptcy)
- Add ability to change the rate at which new companions spawn (Vanilla: 6 weeks, new: every X weeks from 0 to 20)
- Allow users to change the minimum learning rate (Vanilla: 0, new: 0.0 to 16.0)

Changes:
- Replace the static smithing value with a multiplier. In short, an older version of Bannerlord had a static smithing stamina amount per character. It has since been updated to increase with smithing level. This allows us to use the new way while still letting players affect the value with a multiplier
- Increase possible workshop ownership limits to higher values
- Increase possible companion values to higher limits